### PR TITLE
Provide Localization parameter to ResolveLink when available

### DIFF
--- a/Sdl.Web.Mvc/Controllers/PageController.cs
+++ b/Sdl.Web.Mvc/Controllers/PageController.cs
@@ -57,10 +57,12 @@ namespace Sdl.Web.Mvc.Controllers
         /// <returns>null - response is redirected if the URL can be resolved</returns>
         public virtual ActionResult Resolve(string itemId, int localizationId, string defaultItemId = null, string defaultPath = null)
         {
-            string url = SiteConfiguration.LinkResolver.ResolveLink(string.Format("tcm:{0}-{1}-64", localizationId, itemId));
+            var localization = SiteConfiguration.LocalizationResolver.GetLocalization(localizationId.ToString());
+
+            string url = SiteConfiguration.LinkResolver.ResolveLink(string.Format("tcm:{0}-{1}-64", localizationId, itemId), localization: localization);
             if (url == null && defaultItemId != null)
             {
-                url = SiteConfiguration.LinkResolver.ResolveLink(string.Format("tcm:{0}-{1}", localizationId, defaultItemId));
+                url = SiteConfiguration.LinkResolver.ResolveLink(string.Format("tcm:{0}-{1}", localizationId, defaultItemId), localization: localization);
             }
             if (url == null)
             {

--- a/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
@@ -909,6 +909,7 @@ namespace Sdl.Web.Tridion.Mapping
 
         protected virtual void ProcessMetadataField(IField field, IDictionary<string, string> meta)
         {
+            
             if (field.FieldType==FieldType.Embedded)
             {
                 if (field.EmbeddedValues!=null && field.EmbeddedValues.Count>0)

--- a/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
@@ -221,7 +221,7 @@ namespace Sdl.Web.Tridion.Mapping
                     Link link = (Link)entityModel;
                     if (String.IsNullOrEmpty(link.Url))
                     {
-                        link.Url = SiteConfiguration.LinkResolver.ResolveLink(component.Id);
+                        link.Url = SiteConfiguration.LinkResolver.ResolveLink(component.Id, localization: localization);
                     }
                 }
 
@@ -726,7 +726,7 @@ namespace Sdl.Web.Tridion.Mapping
         {
             if (modelType == typeof(string))
             {
-                return SiteConfiguration.LinkResolver.ResolveLink(component.Id);
+                return SiteConfiguration.LinkResolver.ResolveLink(component.Id, localization: localization);
             }
 
             if (!modelType.IsSubclassOf(typeof(EntityModel)))

--- a/Sdl.Web.Tridion/Mapping/DefaultProvider.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultProvider.cs
@@ -182,7 +182,7 @@ namespace Sdl.Web.Tridion.Mapping
                 ILinkResolver linkResolver = SiteConfiguration.LinkResolver;
                 foreach (Teaser item in queryResults)
                 {
-                    item.Link.Url = linkResolver.ResolveLink(item.Link.Url);
+                    item.Link.Url = linkResolver.ResolveLink(item.Link.Url, localization: localization);
                 }
 
                 contentList.ItemListElements = queryResults.Cast<T>().ToList();

--- a/Sdl.Web.Tridion/Mapping/DefaultRichTextProcessor.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultRichTextProcessor.cs
@@ -75,7 +75,7 @@ namespace Sdl.Web.Tridion.Mapping
                     if (!string.IsNullOrEmpty(tcmUri))
                     {
                         // Try to resolve directly to Binary content of MM Component.
-                        linkUrl = linkResolver.ResolveLink(tcmUri, resolveToBinary: true);
+                        linkUrl = linkResolver.ResolveLink(tcmUri, true, localization);
                     }
                 }                
                 if (!string.IsNullOrEmpty(linkUrl))


### PR DESCRIPTION
These tweaks ensure that the Localization parameter is provided to ResolveLink when it is available to the calling method.