### PR TITLE
Add route values to Region MvcData and Controller Actions

### DIFF
--- a/Sdl.Web.Mvc/Html/HtmlHelperExtensions.cs
+++ b/Sdl.Web.Mvc/Html/HtmlHelperExtensions.cs
@@ -383,7 +383,18 @@ namespace Sdl.Web.Mvc.Html
                 string controllerName = mvcData.ControllerName ?? SiteConfiguration.GetRegionController();
                 string controllerAreaName = mvcData.ControllerAreaName ?? SiteConfiguration.GetDefaultModuleName();
 
-                MvcHtmlString result = htmlHelper.Action(actionName, controllerName, new { Region = region, containerSize = containerSize, area = controllerAreaName });
+                RouteValueDictionary parameters = new RouteValueDictionary();
+                parameters["containerSize"] = containerSize;
+                parameters["region"] = region;
+                parameters["area"] = controllerAreaName;
+                if (mvcData.RouteValues != null)
+                {
+                    foreach (string key in mvcData.RouteValues.Keys)
+                    {
+                        parameters[key] = mvcData.RouteValues[key];
+                    }
+                }
+                MvcHtmlString result = htmlHelper.Action(actionName, controllerName, parameters);
 
                 if (WebRequestContext.IsPreview)
                 {

--- a/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
@@ -990,7 +990,7 @@ namespace Sdl.Web.Tridion.Mapping
                     regionMvcData.RegionName = regionNameField.Value;
                 }
             }
-
+            regionMvcData.RouteValues = GetRouteValues(ct);
             return regionMvcData;
         }
 
@@ -1167,22 +1167,29 @@ namespace Sdl.Web.Tridion.Mapping
                 {
                     mvcData.ActionName = ct.MetadataFields["action"].Value;
                 }
-                if (ct.MetadataFields.ContainsKey("routeValues"))
-                {
-                    string[] routeValues = ct.MetadataFields["routeValues"].Value.Split(',');
-                    mvcData.RouteValues = new Dictionary<string, string>(routeValues.Length);
-                    foreach (string routeValue in routeValues)
-                    {
-                        string[] routeValueParts = routeValue.Trim().Split(':');
-                        if (routeValueParts.Length > 1 && !mvcData.RouteValues.ContainsKey(routeValueParts[0]))
-                        {
-                            mvcData.RouteValues.Add(routeValueParts[0], routeValueParts[1]);
-                        }
-                    }
-                }
+                mvcData.RouteValues = GetRouteValues(ct);
             }
 
             return mvcData;
+        }
+
+        private static Dictionary<string, string> GetRouteValues(IComponentTemplate ct, String metaFieldName = "routeValues")
+        {
+            Dictionary<string, string> routeValues = null;
+            if (ct.MetadataFields.ContainsKey(metaFieldName))
+            {
+                string[] routeValuesString = ct.MetadataFields[metaFieldName].Value.Split(',');
+                routeValues = new Dictionary<string, string>(routeValuesString.Length);
+                foreach (string routeValue in routeValuesString)
+                {
+                    string[] routeValueParts = routeValue.Trim().Split(':');
+                    if (routeValueParts.Length > 1 && !routeValues.ContainsKey(routeValueParts[0]))
+                    {
+                        routeValues.Add(routeValueParts[0], routeValueParts[1]);
+                    }
+                }
+            }
+            return routeValues;
         }
     }
 }


### PR DESCRIPTION
Update to allow Region MvcData to also have route Values (similar to Entity MvcData). This allows for the parameterisation of Region views (see issue #28). The implementation in the DefaultModelBuilder is to get the route values from the CT metadata (routeValues), as for entities. In future this can be updated to a more normalised method when Regions are properly modelled in the CM.

Now I can create a single generic N-Column region view and specify **regionCols** and **regionType** route values on the CT metadata (and different region names like 3-Column, 2-Column etc.), which enable me to configure the view column layout logic and render different class and other HTML attributes depending on the regionType.