### PR TITLE
Adding missing Obsolete decoration on PageBase

### DIFF
--- a/Sdl.Web.Common/Interfaces/LegacyContentResolverFacade.cs
+++ b/Sdl.Web.Common/Interfaces/LegacyContentResolverFacade.cs
@@ -13,6 +13,7 @@ namespace Sdl.Web.Common.Interfaces
     {
         #region IContentResolver Members
 
+        [Obsolete("Deprecated in DXA 1.1.")]
         public string DefaultExtensionLessPageName
         {
             get
@@ -25,6 +26,7 @@ namespace Sdl.Web.Common.Interfaces
             }
         }
 
+        [Obsolete("Deprecated in DXA 1.1.")]
         public string DefaultPageName
         {
             get
@@ -37,6 +39,7 @@ namespace Sdl.Web.Common.Interfaces
             }
         }
 
+        [Obsolete("Deprecated in DXA 1.1.")]
         public string DefaultExtension
         {
             get
@@ -57,6 +60,7 @@ namespace Sdl.Web.Common.Interfaces
             return SiteConfiguration.LinkResolver.ResolveLink((string) linkData, localization: contextLocalization);
         }
 
+        [Obsolete("Deprecated in DXA 1.1.")]
         public object ResolveContent(object content, object resolveInstruction = null)
         {
             throw new NotSupportedException("ResolveContent is not supported in DXA 1.1.");

--- a/Sdl.Web.Common/Models/Legacy/PageBase.cs
+++ b/Sdl.Web.Common/Models/Legacy/PageBase.cs
@@ -20,6 +20,7 @@ namespace Sdl.Web.Common.Models
         /// Gets or sets the identifier for the Page.
         /// </summary>
         [SemanticProperty(IgnoreMapping = true)]
+        [Obsolete("Deprecated in DXA 1.1. Use PageModel constructor to set Id instead.")]
         public string Id
         {
             get

--- a/Sdl.Web.Common/Models/Legacy/Region.cs
+++ b/Sdl.Web.Common/Models/Legacy/Region.cs
@@ -20,6 +20,7 @@ namespace Sdl.Web.Common.Models
         /// <summary>
         /// Gets or sets the name of the Region.
         /// </summary>
+        [Obsolete("Deprecated in DXA 1.1.")]
         public string Name
         {
             get


### PR DESCRIPTION
The PageBase.Id property thows an exception, it should be marked as Obsolete.