### PR TITLE
Null check  for ContainerSize in HtmlHelper

### DIFF
--- a/Sdl.Web.Mvc/Html/HtmlHelperExtensions.cs
+++ b/Sdl.Web.Mvc/Html/HtmlHelperExtensions.cs
@@ -212,7 +212,7 @@ namespace Sdl.Web.Mvc.Html
                 string controllerAreaName = mvcData.ControllerAreaName ?? SiteConfiguration.GetDefaultModuleName();
 
                 RouteValueDictionary parameters = new RouteValueDictionary();
-                int parentContainerSize = (int) htmlHelper.ViewData[DxaViewDataItems.ContainerSize];
+                int parentContainerSize = (int) (htmlHelper.ViewData[DxaViewDataItems.ContainerSize] == null ? 0 : htmlHelper.ViewData[DxaViewDataItems.ContainerSize]);
                 if (parentContainerSize == 0)
                 {
                     parentContainerSize = SiteConfiguration.MediaHelper.GridSize;


### PR DESCRIPTION
This happens when you overwrite default controllers without setupviewdata(), especialll ywhen views are not invoked in a normal way .F or example when you load dcp to a page. 
It will be still a approval for have HtmlHelperExtensions have it to do a null check since it assumes viewdata is already there.