### PR TITLE
Fix three code bugs

### DIFF
--- a/Sdl.Web.Common/Extensions/StringExtensions.cs
+++ b/Sdl.Web.Common/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 
 namespace Sdl.Web.Common.Extensions
@@ -23,8 +23,10 @@ namespace Sdl.Web.Common.Extensions
         /// </summary>
         public static bool HasNOrMoreOccurancesOfChar(this string str, int n, char c)
         {
+            if (n <= 0) return true;
+            if (string.IsNullOrEmpty(str)) return false;
             int count = 0;
-            for (int i = 0; i < str.Length || count >= n; i++)
+            for (int i = 0; i < str.Length && count < n; i++)
             {
                 if (str[i] == c)
                 {
@@ -37,7 +39,12 @@ namespace Sdl.Web.Common.Extensions
         /// <summary>
         /// Returns a string converted to camel case.
         /// </summary>
-        public static string ToCamelCase(this string str) => str.Substring(0, 1).ToLower() + str.Substring(1);
+        public static string ToCamelCase(this string str)
+        {
+            if (string.IsNullOrEmpty(str)) return str;
+            if (str.Length == 1) return str.ToLower();
+            return char.ToLower(str[0]) + str.Substring(1);
+        }
 
         /// <summary>
         /// Returns a new string in which all occurances of a specifid string are replaced with a new string

--- a/Sdl.Web.Tridion/Mapping/StronglyTypedTopicBuilder.cs
+++ b/Sdl.Web.Tridion/Mapping/StronglyTypedTopicBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -12,6 +12,7 @@ using Sdl.Web.Common.Extensions;
 using Sdl.Web.Common.Mapping;
 using System.Collections;
 using Sdl.Web.Common.Configuration;
+using System.IO;
 
 namespace Sdl.Web.Tridion.Mapping
 {
@@ -129,18 +130,30 @@ namespace Sdl.Web.Tridion.Mapping
         {
             using (new Tracer(genericTopic))
             {
-                XmlDocument topicXmlDoc = new XmlDocument();
-                topicXmlDoc.LoadXml($"<topic>{genericTopic.TopicBody}</topic>");
+                XmlReaderSettings settings = new XmlReaderSettings
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null
+                };
+                using (var stringReader = new StringReader($"<topic>{genericTopic.TopicBody}</topic>"))
+                using (var xmlReader = XmlReader.Create(stringReader, settings))
+                {
+                    XmlDocument topicXmlDoc = new XmlDocument
+                    {
+                        XmlResolver = null
+                    };
+                    topicXmlDoc.Load(xmlReader);
 
-                XmlElement topicElement = topicXmlDoc.DocumentElement;
+                    XmlElement topicElement = topicXmlDoc.DocumentElement;
 
-                // Inject GenericTopic's TopicTitle as additional HTML element
-                XmlElement topicTitleElement = topicXmlDoc.CreateElement("h1");
-                topicTitleElement.SetAttribute("class", "_topicTitle");
-                topicTitleElement.InnerText = genericTopic.TopicTitle;
-                topicElement.AppendChild(topicTitleElement);
+                    // Inject GenericTopic's TopicTitle as additional HTML element
+                    XmlElement topicTitleElement = topicXmlDoc.CreateElement("h1");
+                    topicTitleElement.SetAttribute("class", "_topicTitle");
+                    topicTitleElement.InnerText = genericTopic.TopicTitle;
+                    topicElement.AppendChild(topicTitleElement);
 
-                return topicElement;
+                    return topicElement;
+                }
             }
         }
 

--- a/Sdl.Web.Tridion/Statics/BinaryFileManager.cs
+++ b/Sdl.Web.Tridion/Statics/BinaryFileManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -319,15 +319,15 @@ namespace Sdl.Web.Tridion.Statics
                 grPhoto.PixelOffsetMode = PixelOffsetMode.HighQuality;
                 grPhoto.DrawImage(imgPhoto, new Rectangle(0, 0, targetW, targetH), cropX, cropY, sourceW, sourceH, GraphicsUnit.Pixel);
                 // Save out to memory and then to a file.  We dispose of all objects to make sure the files don't stay locked.
-                using (MemoryStream memoryStream = new MemoryStream())
-                {
-                    bmPhoto.Save(memoryStream, imageFormat);
-                    original.Dispose();
-                    imgPhoto.Dispose();
-                    bmPhoto.Dispose();
-                    grPhoto.Dispose();
-                    return memoryStream.GetBuffer();
-                }
+                                    using (MemoryStream memoryStream = new MemoryStream())
+                    {
+                        bmPhoto.Save(memoryStream, imageFormat);
+                        original.Dispose();
+                        imgPhoto.Dispose();
+                        bmPhoto.Dispose();
+                        grPhoto.Dispose();
+                        return memoryStream.ToArray();
+                    }
             }
         }
 


### PR DESCRIPTION
Fixes three bugs: a logic error/null-safety in string extensions, an XXE vulnerability in XML parsing, and a binary corruption issue in image resizing.

---
<a href="https://cursor.com/background-agent?bcId=bc-312f376a-0c22-438f-9d76-f2b945055e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-312f376a-0c22-438f-9d76-f2b945055e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

